### PR TITLE
Add some functionality to DA/TA page

### DIFF
--- a/panel.html
+++ b/panel.html
@@ -10,7 +10,7 @@
     <div id="tabs">
         <ul class="tab">
             <li><a href="#damageLogger">Damage</a></li>
-            <li><a href="#AutoLogger">DA/TA</a></li>
+            <li><a href="#AutoLogger">Autoattack info</a></li>
         </ul>
     
         <!-- Tab 1-->

--- a/panel.html
+++ b/panel.html
@@ -10,7 +10,7 @@
     <div id="tabs">
         <ul class="tab">
             <li><a href="#damageLogger">Damage</a></li>
-            <li><a href="#DATALogger">DA/TA</a></li>
+            <li><a href="#AutoLogger">DA/TA</a></li>
         </ul>
     
         <!-- Tab 1-->
@@ -106,9 +106,9 @@
         </div>
         
         <!-- Tab 2 -->
-        <div id="DATALogger">
-            <h1>Approximate DA/TA rates</h1>
-            <div id="characterDATAInfo">
+        <div id="AutoLogger">
+            <h1>Autoattack information</h1>
+            <div id="characterAutoInfo">
             </div>
         </div>
         

--- a/panel.js
+++ b/panel.js
@@ -137,10 +137,10 @@ function updateCharacterInfo() {
     }
 }
 
-function updateCharacterDATAInfo() {
-    $("#characterDATAInfo").html("");
+function updateCharacterAutoInfo() {
+    $("#characterAutoInfo").html("");
     for (var i = 0; i < characterInfo.length; i++) {
-        
+        var avgDmg = characterInfo.attackDamage / (turnNumber + characterInfo[i].das + characterInfo[i].tas);
         if ((turnNumber - characterInfo[i].tas - characterInfo[i].cas) != 0) {
             var daRate = (characterInfo[i].das / (turnNumber - characterInfo[i].tas - characterInfo[i].cas) * 100).toFixed(2);
         } else {
@@ -151,7 +151,7 @@ function updateCharacterDATAInfo() {
         } else {
             taRate = 0;
         }
-        $("#characterDATAInfo").append("<div class=\"character\"><li class=\"flex-container\"><p>" + characterInfo[i].name +"</p></li><li class=\"flex-container\"><p class=\"sub\">DA rate</p><p>" + daRate + "%</p></li><li class=\"flex-container\"><p class=\"sub\">TA rate</p><p>" + taRate + "%</p></li><div>")
+        $("#characterAutoInfo").append("<div class=\"character\"><li class=\"flex-container\"><p>" + characterInfo[i].name +"</p></li><li class=\"flex-container\"><p class=\"sub\">Average autoattack damage</p><p>" + displayNumbers(avgDmg) + "</p></li><li class=\"flex-container\"><p class=\"sub\">DA rate</p><p>" + daRate + "%</p></li><li class=\"flex-container\"><p class=\"sub\">TA rate</p><p>" + taRate + "%</p></li><div>")
     }
 }
 
@@ -665,7 +665,7 @@ chrome.devtools.network.onRequestFinished.addListener(function(req) {
                     total: 0,
                     details: []
                 };
-                updateCharacterDATAInfo();
+                updateCharacterAutoInfo();
                 
                 //status at the end of turn
                 var status = data.status;
@@ -855,7 +855,7 @@ chrome.devtools.network.onRequestFinished.addListener(function(req) {
                 }
                 
                 updateCharacterInfo();
-                updateCharacterDATAInfo()
+                updateCharacterAutoInfo()
                 
                 //team formation
                 if (startinfo.formation != undefined) {

--- a/panel.js
+++ b/panel.js
@@ -407,8 +407,6 @@ function resetDamage() {
         characterInfo[i].cas = 0;
     }
 
-    console.log(characterInfo);
-    
     updateStatistics();
 }
 

--- a/panel.js
+++ b/panel.js
@@ -107,6 +107,19 @@ function updateCharacterInfo() {
         p.text(displayNumbers(characterInfo[i].attackDamage));
         damageDetail.append(p);
         breakdown.append(damageDetail);
+
+        //ougi damage
+        damageDetail = $("<li>");
+        damageDetail.addClass("flex-container");
+        var p = $("<p>");
+        p.addClass("sub");
+        p.text("ougi damage");
+        damageDetail.append(p);
+
+        p = $("<p>");
+        p.text(displayNumbers(characterInfo[i].ougiDamage));
+        damageDetail.append(p);
+        breakdown.append(damageDetail);
         
         //skill damage
         damageDetail = $("<li>");
@@ -140,18 +153,16 @@ function updateCharacterInfo() {
 function updateCharacterAutoInfo() {
     $("#characterAutoInfo").html("");
     for (var i = 0; i < characterInfo.length; i++) {
-        var avgDmg = characterInfo.attackDamage / (turnNumber + characterInfo[i].das + characterInfo[i].tas);
-        if ((turnNumber - characterInfo[i].tas - characterInfo[i].cas) != 0) {
-            var daRate = (characterInfo[i].das / (turnNumber - characterInfo[i].tas - characterInfo[i].cas) * 100).toFixed(2);
-        } else {
-            var daRate = 0;
-        }
-        if ((turnNumber - characterInfo[i].cas) != 0) {
-            var taRate = (characterInfo[i].tas / (turnNumber - characterInfo[i].cas) * 100 ).toFixed(2);
-        } else {
-            taRate = 0;
-        }
-        $("#characterAutoInfo").append("<div class=\"character\"><li class=\"flex-container\"><p>" + characterInfo[i].name +"</p></li><li class=\"flex-container\"><p class=\"sub\">Average autoattack damage</p><p>" + displayNumbers(avgDmg) + "</p></li><li class=\"flex-container\"><p class=\"sub\">DA rate</p><p>" + daRate + "%</p></li><li class=\"flex-container\"><p class=\"sub\">TA rate</p><p>" + taRate + "%</p></li><div>")
+        var avgDmg = "N/A";
+        var daRate = "N/A";
+        var taRate = "N/A";
+        if (characterInfo[i].attacks != 0)
+            avgDmg = (characterInfo[i].attackDamage / (characterInfo[i].attacks)).toFixed(2);
+        if ((characterInfo[i].turns - characterInfo[i].tas - characterInfo[i].cas) != 0)
+            daRate = (characterInfo[i].das / (characterInfo[i].turns - characterInfo[i].tas - characterInfo[i].cas) * 100).toFixed(2) + "%";
+        if ((characterInfo[i].turns - characterInfo[i].cas) != 0)
+            taRate = (characterInfo[i].tas / (characterInfo[i].turns - characterInfo[i].cas) * 100 ).toFixed(2) + "%";
+        $("#characterAutoInfo").append("<div class=\"character\"><li class=\"flex-container\"><p>" + characterInfo[i].name +"</p></li><li class=\"flex-container\"><p class=\"sub\">Turns in combat</p><p>" + displayNumbers(characterInfo[i].turns) + "</p></li><li class=\"flex-container\"><p class=\"sub\">Average autoattack damage</p><p>" + displayNumbers(avgDmg) + "</p></li><li class=\"flex-container\"><p class=\"sub\">DA rate</p><p>" + daRate + "</p></li><li class=\"flex-container\"><p class=\"sub\">TA rate</p><p>" + taRate + "</p></li><div>");
     }
 }
 
@@ -387,10 +398,16 @@ function resetDamage() {
     //character info
     for(var i = 0; i < characterInfo.length; i++) {
         characterInfo[i].attackDamage = 0;
+        characterInfo[i].ougiDamage = 0;
         characterInfo[i].skillDamage = 0;
+        characterInfo[i].turns = 0;
+        characterInfo[i].attacks = 0;
         characterInfo[i].das = 0;
         characterInfo[i].tas = 0;
+        characterInfo[i].cas = 0;
     }
+
+    console.log(characterInfo);
     
     updateStatistics();
 }
@@ -458,7 +475,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //first character (i.e. Gran/Djeeta)
         name: "Ally 1",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0, // number of turns taken
+        attacks: 0, // number of autoattacks (turns + das + 2*tas)
         das: 0,
         tas: 0,
         cas: 0
@@ -466,7 +486,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //second character
         name: "Ally 2",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0,
+        attacks: 0,
         das: 0,
         tas: 0,
         cas: 0
@@ -474,7 +497,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //third character
         name: "Ally 3",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0,
+        attacks: 0,
         das: 0,
         tas: 0,
         cas: 0
@@ -482,7 +508,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //fourth character
         name: "Ally 4",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0,
+        attacks: 0,
         das: 0,
         tas: 0,
         cas: 0
@@ -490,7 +519,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //fifth character
         name: "Ally 5",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0,
+        attacks: 0,
         das: 0,
         tas: 0,
         cas: 0
@@ -498,7 +530,10 @@ var characterInfo = [ //character info with name, damage dealt
     { //sixth character
         name: "Ally 6",
         attackDamage: 0,
+        ougiDamage: 0,
         skillDamage: 0,
+        turns: 0,
+        attacks: 0,
         das: 0,
         tas: 0,
         cas: 0
@@ -631,13 +666,22 @@ chrome.devtools.network.onRequestFinished.addListener(function(req) {
                     
                     //increase individual character totals
                     if(charaDetails.pos != -1) {
-                        characterInfo[newFormation[charaDetails.pos]].attackDamage += charaDetails.total;
-                        if(charaDetails.type == "Double") {
-                            characterInfo[newFormation[charaDetails.pos]].das++;
+                        var pos = newFormation[charaDetails.pos];
+                        characterInfo[pos].turns++;
+                        if (charaDetails.type == "Single") {
+                            characterInfo[pos].attackDamage += charaDetails.total;
+                            characterInfo[pos].attacks++;
+                        } else if (charaDetails.type == "Double") {
+                            characterInfo[pos].attackDamage += charaDetails.total;
+                            characterInfo[pos].das++;
+                            characterInfo[pos].attacks += 2;
                         } else if ( charaDetails.type == "Triple") {
-                            characterInfo[newFormation[charaDetails.pos]].tas++;
+                            characterInfo[pos].attackDamage += charaDetails.total;
+                            characterInfo[pos].tas++;
+                            characterInfo[pos].attacks += 3;
                         } else if ( charaDetails.type == "CA") {
-                            characterInfo[newFormation[charaDetails.pos]].cas++;
+                            characterInfo[pos].ougiDamage += charaDetails.total;
+                            characterInfo[pos].cas++;
                         }
                     }
                     charaDetails = { //reset
@@ -855,7 +899,7 @@ chrome.devtools.network.onRequestFinished.addListener(function(req) {
                 }
                 
                 updateCharacterInfo();
-                updateCharacterAutoInfo()
+                updateCharacterAutoInfo();
                 
                 //team formation
                 if (startinfo.formation != undefined) {

--- a/panel.js
+++ b/panel.js
@@ -86,7 +86,7 @@ function updateCharacterInfo() {
         character = $("<li>");
         character.addClass("flex-container");
         character.addClass("toggleable");
-        character.html("<p>\> " + characterInfo[i].name +"</p>" + "<p>" + displayNumbers(characterInfo[i].skillDamage + characterInfo[i].attackDamage) + "</p>");
+        character.html("<p>\> " + characterInfo[i].name +"</p>" + "<p>" + displayNumbers(characterInfo[i].skillDamage + characterInfo[i].attackDamage + characterInfo[i].ougiDamage) + "</p>");
         
         $("#characterInfo").append(character);
         


### PR DESCRIPTION
Added individual turn counters and average auto damage to the DA/TA page and renamed it to Auto info.

Might be worth thinking about putting the statistics somewhere else or moving character page info to this tab and calling it character info or something.

Should fix #2 

![image](https://cloud.githubusercontent.com/assets/2347889/18866884/c410799a-84dc-11e6-840f-73702e3975b0.png)

![image](https://cloud.githubusercontent.com/assets/2347889/18866929/f91d282c-84dc-11e6-9ac6-9ed4566263a6.png)
